### PR TITLE
Roll version to 1.9-SNAPSHOT

### DIFF
--- a/container/overlay/tomcat/conf/catalina.properties
+++ b/container/overlay/tomcat/conf/catalina.properties
@@ -130,7 +130,7 @@ fs.root.dir=${catalina.home}/db
 rest.api.server=http://localhost:8080/
 rest.api.username=aio
 rest.api.password=Sm9@wojk
-application.version=1.8
+application.version=1.9-SNAPSHOT
 spring.main.banner-mode=off
 
 # SDO H2 database ports (used internally)

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -6,22 +6,22 @@
 
   <groupId>org.sdo.aio</groupId>
   <artifactId>container</artifactId>
-  <version>1.8</version>
+  <version>1.9-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>aio</artifactId>
-    <version>1.8</version>
+    <version>1.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 
   <properties>
-    <rendezvous.war>rendezvous-1.8.war</rendezvous.war>
-    <manufacturer.war>manufacturer-webapp-1.8.war</manufacturer.war>
-    <to0service.war>to0serviceimpl-1.8.war</to0service.war>
-    <ops.war>opsimpl-1.8.war</ops.war>
-    <ocs.war>ocsfs-1.8.war</ocs.war>
+    <rendezvous.war>rendezvous-1.9-SNAPSHOT.war</rendezvous.war>
+    <manufacturer.war>manufacturer-webapp-1.9-SNAPSHOT.war</manufacturer.war>
+    <to0service.war>to0serviceimpl-1.9-SNAPSHOT.war</to0service.war>
+    <ops.war>opsimpl-1.9-SNAPSHOT.war</ops.war>
+    <ocs.war>ocsfs-1.9-SNAPSHOT.war</ocs.war>
     <tomcat.folder>apache-tomcat-9.0.33</tomcat.folder>
     <tomcat.url>https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.33/bin/apache-tomcat-9.0.33.zip</tomcat.url>
   </properties>
@@ -30,35 +30,35 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>rendezvous</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.sct</groupId>
       <artifactId>manufacturer-webapp</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.iotplatformsdk.to0service</groupId>
       <artifactId>to0serviceimpl</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.iotplatformsdk.ocs</groupId>
       <artifactId>ocsfs</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.iotplatformsdk.ops</groupId>
       <artifactId>opsimpl</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
       <type>war</type>
     </dependency>
 
@@ -66,7 +66,7 @@
     <dependency>
       <groupId>org.sdo.demo</groupId>
       <artifactId>services</artifactId>
-      <version>1.8</version>
+      <version>1.9-SNAPSHOT</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload -->

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
   <artifactId>aio</artifactId>
   <groupId>org.sdo</groupId>
-  <version>1.8</version>
+  <version>1.9-SNAPSHOT</version>
   <name>AIO</name>
   <packaging>pom</packaging>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -13,13 +13,13 @@
 
   <groupId>org.sdo.demo</groupId>
   <artifactId>services</artifactId>
-  <version>1.8</version>
+  <version>1.9-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <parent>
     <groupId>org.sdo</groupId>
     <artifactId>aio</artifactId>
-    <version>1.8</version>
+    <version>1.9-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 


### PR DESCRIPTION
The version for AIO packages are rolled to 1.9-SNAPSHOT to prepare for
next release. Also the dependencies related to Secure Device Onboard
components have been updated to 1.9-SNAPSHOT.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>