### PR TITLE
Fixed timeout in AioServlet

### DIFF
--- a/services/src/main/java/org/sdo/demo/AioApiServlet.java
+++ b/services/src/main/java/org/sdo/demo/AioApiServlet.java
@@ -215,7 +215,7 @@ public class AioApiServlet extends HttpServlet {
       if (isMethodAllow(req.getMethod())) {
         AsyncContext asyncCtx = req.startAsync();
 
-        asyncCtx.setTimeout(9000);
+        asyncCtx.setTimeout(0);
 
         if (req.getMethod().equals("PUT")) {
           new Thread(() -> putAsync(asyncCtx)).start();


### PR DESCRIPTION
Previous timeout was set to 9 seconds resulting in connnection closed
if REST call took longer than 9 seconds.  New timeout is 0 (infinite).
Now AIO servlet does not timeout

Signed-off-by: Templeton, Randall <randall.f.templeton@intel.com>