### PR TITLE
Fixing svi.json to pickup binsh instead of sh-linux

### DIFF
--- a/container/overlay/tomcat/db/v1/defaults/svi.json
+++ b/container/overlay/tomcat/db/v1/defaults/svi.json
@@ -31,8 +31,8 @@
     "module": "sdo_sys",
     "msg": "exec",
     "valueLen": -1,
-    "valueId": "sh-linux64",
+    "valueId": "binsh-linux64",
     "enc": "base64"
   }
 ]
-   
+


### PR DESCRIPTION
  Fixing svi.json to pickup binsh instead of sh-linux.
  As sh-linux with DAL device results in an error.

Signed-off-by: Davis Benny <davis.benny@intel.com>