### PR TITLE
Add demo directory to store build artifact

### DIFF
--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -24,7 +24,7 @@ node('ubuntu18.04-OnDemand'){
       sh 'cd $WORKSPACE/supply-chain-tools; mvn clean install'
       sh 'cd $WORKSPACE/all-in-one-demo; mvn clean install'
       print "Archive the artifacts"
-      archiveArtifacts artifacts: 'all-in-one-demo/container/target/aio.tar.gz', fingerprint: true, allowEmptyArchive: false
+      archiveArtifacts artifacts: 'all-in-one-demo/demo/aio.tar.gz', fingerprint: true, allowEmptyArchive: false
     }
     
     try{

--- a/Jenkinsfile.yml
+++ b/Jenkinsfile.yml
@@ -50,7 +50,7 @@ node('ubuntu18.04-OnDemand'){
         '''
         print "Copy aio artifacts to sdo-test/binaries folder"
         sh '''
-          cp -r all-in-one-demo/container/target/aio.tar.gz sdo-test/binaries/all-in-one-demo
+          cp -r all-in-one-demo/demo/aio.tar.gz sdo-test/binaries/all-in-one-demo
           tar -xvf sdo-test/binaries/all-in-one-demo/aio.tar.gz -C sdo-test/binaries/all-in-one-demo/ --strip=1
         '''  
         print "AIO smoke Tests with client-sdk Device PRI Device"

--- a/build/build.sh
+++ b/build/build.sh
@@ -40,7 +40,7 @@ if [ "$use_remote" = "1" ]; then
   cd /tmp/all-in-one-demo/
   git checkout $REPO_BRANCH
   mvn clean install
-  cp -r ./container/target/ /home/sdouser/all-in-one-demo/container/
+  cp -r ./demo/aio.tar.gz /home/sdouser/all-in-one-demo/demo/
 else
   echo "Building local copy"
   cd /home/sdouser/all-in-one-demo/

--- a/container/pom.xml
+++ b/container/pom.xml
@@ -25,6 +25,7 @@
     <ocs.war>ocsfs-1.9-SNAPSHOT.war</ocs.war>
     <tomcat.folder>apache-tomcat-9.0.37</tomcat.folder>
     <tomcat.url>https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.37/bin/apache-tomcat-9.0.37.zip</tomcat.url>
+    <project.demo.directory>../demo</project.demo.directory>
   </properties>
 
   <dependencies>
@@ -254,7 +255,7 @@
                 <mkdir dir="${project.build.directory}/deploy/aio/tomcat/db/v1/devices"/>
 
                 <echo message="tar aio" />
-                <tar tarfile="${project.build.directory}/aio.tar.gz"
+                <tar tarfile="${project.demo.directory}/aio.tar.gz"
                   basedir="${project.build.directory}/deploy"
                   longfile="gnu"
                   compression="gzip" />


### PR DESCRIPTION
Update the build to copy the output tarball to demo folder. This would
align the behaviour of build script with other components.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>