### PR TITLE
Update On-Die ECDSA properties

### DIFF
--- a/container/overlay/tomcat/conf/catalina.properties
+++ b/container/overlay/tomcat/conf/catalina.properties
@@ -190,6 +190,11 @@ rest.api.ciphers.path=ocs/v1/ciphers/{deviceId}
 rest.api.session.path=ocs/v1/devices/{deviceId}/sessioninfo
 to0.rest.api=${rest.api.server}to0/v1/to0/devices
 
+# SDO IOT Platform OPS onDie-ecdsa Configurations
+org.sdo.ops.ondie-ecdsa-material-path=ondie-ecdsa-material
+org.sdo.ops.ondie-ecdsa-material-urls=https://tsci.intel.com/content/OnDieCA/certs/,https://tsci.intel.com/content/OnDieCA/crls/
+org.sdo.ops.ondie-ecdsa-material-update=true
+
 # IOT Platform MTLS Configurations
 server.ssl.key-store-type=PKCS12
 server.ssl.trust-store-type=PKCS12


### PR DESCRIPTION
    Updating AIO properties to add On-Die ECDSA support.
    New onDie-ECDSA related properties are added to
    tomcat/catalina.properties.

Signed-off-by: Davis Benny <davis.benny@intel.com>