### PR TITLE
Fixing AIO to support EHL onboarding.

### DIFF
--- a/container/overlay/tomcat/conf/catalina.properties
+++ b/container/overlay/tomcat/conf/catalina.properties
@@ -191,9 +191,15 @@ rest.api.session.path=ocs/v1/devices/{deviceId}/sessioninfo
 to0.rest.api=${rest.api.server}to0/v1/to0/devices
 
 # SDO IOT Platform OPS onDie-ecdsa Configurations
-org.sdo.ops.ondie-ecdsa-material-path=ondie-ecdsa-material
+org.sdo.ops.ondie-ecdsa-material-path=${catalina.home}/db/ondiecache
 org.sdo.ops.ondie-ecdsa-material-urls=https://tsci.intel.com/content/OnDieCA/certs/,https://tsci.intel.com/content/OnDieCA/crls/
-org.sdo.ops.ondie-ecdsa-material-update=true
+org.sdo.ops.ondie-ecdsa-material-update=false
+
+# SDO onDie-ecdsa Configurations
+sdo.ondiecache.cachedir=${catalina.home}/db/ondiecache
+sdo.ondiecache.revocations=false
+sdo.ondiecache.urlsources=https://tsci.intel.com/content/OnDieCA/crls/
+sdo.ondiecache.autoupdate=false
 
 # IOT Platform MTLS Configurations
 server.ssl.key-store-type=PKCS12

--- a/container/overlay/tomcat/conf/catalina.properties
+++ b/container/overlay/tomcat/conf/catalina.properties
@@ -195,7 +195,7 @@ org.sdo.ops.ondie-ecdsa-material-path=${catalina.home}/db/ondiecache
 org.sdo.ops.ondie-ecdsa-material-urls=https://tsci.intel.com/content/OnDieCA/certs/,https://tsci.intel.com/content/OnDieCA/crls/
 org.sdo.ops.ondie-ecdsa-material-update=false
 
-# SDO onDie-ecdsa Configurations
+# SDO SCT, PRI onDie-ecdsa Configurations
 sdo.ondiecache.cachedir=${catalina.home}/db/ondiecache
 sdo.ondiecache.revocations=false
 sdo.ondiecache.urlsources=https://tsci.intel.com/content/OnDieCA/crls/


### PR DESCRIPTION
  Fixing AIO to support EHL device onboarding. This commit includes
  new variables related to onDie-ECDSA in tomcat/catalina.properties
 and an empty folder 'ondiecache' to store onDie certs and crls.

Signed-off-by: Davis Benny <davis.benny@intel.com>