### PR TITLE
Set the sandbox EPID verifier as default for demo

### DIFF
--- a/container/overlay/tomcat/conf/catalina.properties
+++ b/container/overlay/tomcat/conf/catalina.properties
@@ -224,7 +224,7 @@ org.sdo.to0.ownersign.to0d.ws=PT1H
 
 # SDO PRI Rendezvous Service Configurations
 org.sdo.epid.test-mode=false
-#org.sdo.epid.epid-online-url=https://verify.epid.trustedservices.intel.com
+org.sdo.epid.epid-online-url=https://verify.epid-sbx.trustedservices.intel.com
 org.sdo.pkix.trust-anchors=
 org.sdo.pkix.accept-errors=UNSPECIFIED, UNDETERMINED_REVOCATION_STATUS
 org.sdo.pkix.revocation-options=PREFER_CRLS, SOFT_FAIL, NO_FALLBACK


### PR DESCRIPTION
For demo operations, the sandbox EPID verifier service is used instead
of production EPID verifier service. Both the services use the same
backend logic.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>