### PR TITLE
Migrate to use Ubuntu 20.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Device Onboard protocol using different client implementations.
 # Getting Started with the SDO All-In-One Demo
 
 The following are the system constraints for the All-in-One demo.
-- Operating System: Ubuntu* 18.04
+- Operating System: Ubuntu* 20.04
 - Java* Development Kit 11
 - Apache Maven* 3.5.4 (Optional) software for building the demo from source
 - Java IDE (Optional) for convenience in modifying the source code

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:bionic
+FROM ubuntu:20.04
 
 RUN apt-get update && \
     apt-get install -y git  \

--- a/container/overlay/Dockerfile
+++ b/container/overlay/Dockerfile
@@ -2,7 +2,7 @@
 # Build docker container for Data Access Service
 #
 #
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install openjdk-11-jre-headless --yes
 

--- a/container/overlay/README.md
+++ b/container/overlay/README.md
@@ -8,7 +8,7 @@ different client implementations.
 # Getting Started with the SDO All-In-One Demo
 
 The following are the system constraints for the All-in-One demo.
-- Operating System: Ubuntu* 18.04
+- Operating System: Ubuntu* 20.04
 - Java* Runtime Environment 11
 - Docker 18.09
 - Docker compose 1.21.2

--- a/container/overlay/dockerfiles/Dockerfile-rendezvous
+++ b/container/overlay/dockerfiles/Dockerfile-rendezvous
@@ -1,7 +1,7 @@
 # Copyright 2020 Intel Corporation
 # SPDX-License-Identifier: Apache 2.0
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y openjdk-11-jdk
 RUN apt-get install -y wget
 


### PR DESCRIPTION
Migrate build and runtime containers to use Ubuntu 20.04.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>