### PR TITLE
Adding license header in Test files.

### DIFF
--- a/services/src/test/java/org/sdo/demo/AioApiServletTest.java
+++ b/services/src/test/java/org/sdo/demo/AioApiServletTest.java
@@ -1,3 +1,6 @@
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
 package org.sdo.demo;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -13,7 +16,6 @@ import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 
 class AioApiServletTest {
-
 
   private MockHttpServletRequest request;
   private MockHttpServletResponse response;
@@ -78,7 +80,6 @@ class AioApiServletTest {
         obj.copyFile(request, response, Paths.get("/home")));
   }
 
-
   @Test
   void isMethodAllow() {
     String method ="GET";
@@ -86,6 +87,5 @@ class AioApiServletTest {
     boolean actual = obj.isMethodAllow(method);
     assertEquals(expected, actual);
   }
-
 
 }

--- a/services/src/test/java/org/sdo/demo/AioDbTest.java
+++ b/services/src/test/java/org/sdo/demo/AioDbTest.java
@@ -1,3 +1,6 @@
+// Copyright 2020 Intel Corporation
+// SPDX-License-Identifier: Apache 2.0
+
 package org.sdo.demo;
 
 import static org.junit.jupiter.api.Assertions.*;


### PR DESCRIPTION
 Adding license header in Test files (AioDb and AioApiServlet).

Signed-off-by: Davis Benny <davis.benny@intel.com>