### PR TITLE
Fixing the dependency issue

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -30,6 +30,18 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.30</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-simple</artifactId>
+      <version>1.7.30</version>
+   </dependency>
+
+    <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>rendezvous</artifactId>
       <version>1.10-SNAPSHOT</version>
@@ -91,7 +103,7 @@
       <version>1.4</version>
     </dependency>
 
-    <dependency>
+   <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <version>1.4.200</version>


### PR DESCRIPTION
  Adding slf4j dependency to the container.
  Without the addition of slf4j dependency in the container,
  the build pipeline was failing intermediately.

Signed-off-by: Davis Benny <davis.benny@intel.com>