### PR TITLE
Update AIO to support HTTPS

### DIFF
--- a/container/overlay/tomcat/conf/catalina.properties
+++ b/container/overlay/tomcat/conf/catalina.properties
@@ -128,6 +128,7 @@ tomcat.util.buf.StringCache.byte.enabled=true
 # SDO configuration
 fs.root.dir=${catalina.home}/db
 rest.api.server=http://localhost:8080/
+org.sdo.rv.scheme=http://
 application.version=1.10
 spring.main.banner-mode=off
 

--- a/container/overlay/tomcat/conf/server.xml
+++ b/container/overlay/tomcat/conf/server.xml
@@ -86,11 +86,10 @@
     -->
     <!--
     <Connector port="8443" protocol="org.apache.coyote.http11.Http11NioProtocol"
-               maxThreads="150" SSLEnabled="true">
-        <SSLHostConfig>
-            <Certificate certificateKeystoreFile="conf/localhost-rsa.jks"
-                         type="RSA" />
-        </SSLHostConfig>
+               maxThreads="150" scheme="https" secure="true" SSLEnabled="true">
+            keystoreFile="<Path to JKS File>" 
+            keystorePass="<JKS Store Password>"
+            clientAuth="false" sslProtocol="TLS">
     </Connector>
     -->
     <!-- Define an SSL/TLS HTTP/1.1 Connector on port 8443 with HTTP/2


### PR DESCRIPTION
README updated to show how to configure tomcat for TLS.
AIO Releay Servlet updated to use SSLContext.
AioDB updated to allow SCT to using http for RV Ifo.

Signed-off-by: Templeton, Randall <randall.f.templeton@intel.com>