### PR TITLE
Update build script for 1.10-rel branch

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,6 +3,8 @@
 
 FROM ubuntu:20.04
 
+ENV DEBIAN_FRONTEND=noninteractive
+
 RUN apt-get update && \
     apt-get install -y git  \
     openjdk-11-jdk-headless \

--- a/build/build.sh
+++ b/build/build.sh
@@ -18,7 +18,7 @@ REPO_AIO=https://github.com/secure-device-onboard/all-in-one-demo.git
 REPO_RV=https://github.com/secure-device-onboard/rendezvous-service.git
 
 # The same branch will be used to build other SDO components( PRI, IOT, RV & SCT).
-REPO_BRANCH=master
+REPO_BRANCH=1.10-rel
 
 cd /home/sdouser/
 git clone $REPO_IOT


### PR DESCRIPTION
The existing build was pointing to the master branch of dependent
repositories, but the related changes are available on 1.10-rel branch.

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>