### PR TITLE
Update version of third-party packages

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -17,14 +17,23 @@
   </parent>
 
   <properties>
-    <rendezvous.war>rendezvous-1.10.2-SNAPSHOT.war</rendezvous.war>
-    <rvservice.war>rendezvous-service-1.10.2-SNAPSHOT.war</rvservice.war>
-    <manufacturer.war>manufacturer-webapp-1.10.2-SNAPSHOT.war</manufacturer.war>
-    <to0service.war>to0serviceimpl-1.10.2-SNAPSHOT.war</to0service.war>
-    <ops.war>opsimpl-1.10.2-SNAPSHOT.war</ops.war>
-    <ocs.war>ocsfs-1.10.2-SNAPSHOT.war</ocs.war>
-    <tomcat.folder>apache-tomcat-9.0.43</tomcat.folder>
-    <tomcat.url>https://archive.apache.org/dist/tomcat/tomcat-9/v9.0.43/bin/apache-tomcat-9.0.43.zip</tomcat.url>
+    <sdo.version>1.10.2-SNAPSHOT</sdo.version>
+    <commons-io.version>2.8.0</commons-io.version>
+    <commons-dbcp2.version>2.8.0</commons-dbcp2.version>
+    <commons-fileupload.version>1.4</commons-fileupload.version>
+    <h2.version>1.4.200</h2.version>
+    <json.version>20210307</json.version>
+    <slf4j-api.version>1.7.30</slf4j-api.version>
+    <slf4j-simple.version>1.7.30</slf4j-simple.version>
+    <tomcat.version>9.0.46</tomcat.version>
+    <rendezvous.war>rendezvous-${sdo.version}.war</rendezvous.war>
+    <rvservice.war>rendezvous-service-${sdo.version}.war</rvservice.war>
+    <manufacturer.war>manufacturer-webapp-${sdo.version}.war</manufacturer.war>
+    <to0service.war>to0serviceimpl-${sdo.version}.war</to0service.war>
+    <ops.war>opsimpl-${sdo.version}.war</ops.war>
+    <ocs.war>ocsfs-${sdo.version}.war</ocs.war>
+    <tomcat.folder>apache-tomcat-${tomcat.version}</tomcat.folder>
+    <tomcat.url>https://archive.apache.org/dist/tomcat/tomcat-9/v${tomcat.version}/bin/apache-tomcat-${tomcat.version}.zip</tomcat.url>
     <project.demo.directory>../demo</project.demo.directory>
   </properties>
 
@@ -32,48 +41,48 @@
     <dependency>
       <groupId>org.sdo</groupId>
       <artifactId>rendezvous</artifactId>
-      <version>1.10.2-SNAPSHOT</version>
+      <version>${sdo.version}</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20200518</version>
+      <version>${json.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.rendezvous</groupId>
       <artifactId>rendezvous-service</artifactId>
-      <version>1.10.2-SNAPSHOT</version>
+      <version>${sdo.version}</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.sct</groupId>
       <artifactId>manufacturer-webapp</artifactId>
-      <version>1.10.2-SNAPSHOT</version>
+      <version>${sdo.version}</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.iotplatformsdk.to0service</groupId>
       <artifactId>to0serviceimpl</artifactId>
-      <version>1.10.2-SNAPSHOT</version>
+      <version>${sdo.version}</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.iotplatformsdk.ocs</groupId>
       <artifactId>ocsfs</artifactId>
-      <version>1.10.2-SNAPSHOT</version>
+      <version>${sdo.version}</version>
       <type>war</type>
     </dependency>
 
     <dependency>
       <groupId>org.sdo.iotplatformsdk.ops</groupId>
       <artifactId>opsimpl</artifactId>
-      <version>1.10.2-SNAPSHOT</version>
+      <version>${sdo.version}</version>
       <type>war</type>
     </dependency>
 
@@ -81,46 +90,46 @@
     <dependency>
       <groupId>org.sdo.demo</groupId>
       <artifactId>services</artifactId>
-      <version>1.10.2-SNAPSHOT</version>
+      <version>${sdo.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>${slf4j-api.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
-      <version>1.7.30</version>
+      <version>${slf4j-simple.version}</version>
    </dependency>
 
     <!-- https://mvnrepository.com/artifact/commons-fileupload/commons-fileupload -->
     <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
-      <version>1.4</version>
+      <version>${commons-fileupload.version}</version>
     </dependency>
 
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.200</version>
+      <version>${h2.version}</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.6</version>
+      <version>${commons-io.version}</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-dbcp2 -->
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-dbcp2</artifactId>
-      <version>2.7.0</version>
+      <version>${commons-dbcp2.version}</version>
     </dependency>
   </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven-checkstyle-plugin.version>3.1.0</maven-checkstyle-plugin.version>
+    <maven-checkstyle-plugin.version>3.1.2</maven-checkstyle-plugin.version>
     <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
     <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
   </properties>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,7 +24,14 @@
   </parent>
 
   <properties>
-    <tomcat.version>9.0.43</tomcat.version>
+    <tomcat.version>9.0.46</tomcat.version>
+    <h2.version>1.4.200</h2.version>
+    <json.version>20210307</json.version>
+    <slf4j-api.version>1.7.30</slf4j-api.version>
+    <spring-test.version>5.3.7</spring-test.version>
+    <spring-core.version>5.3.7</spring-core.version>
+    <junit-jupiter.version>5.7.2</junit-jupiter.version>
+    <mockito-all.version>1.10.19</mockito-all.version>
   </properties>
 
   <dependencies>
@@ -32,20 +39,20 @@
     <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
-      <version>1.4.200</version>
+      <version>${h2.version}</version>
     </dependency>
 
     <!-- https://mvnrepository.com/artifact/org.json/json -->
     <dependency>
       <groupId>org.json</groupId>
       <artifactId>json</artifactId>
-      <version>20200518</version>
+      <version>${json.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
-      <version>1.7.30</version>
+      <version>${slf4j-api.version}</version>
     </dependency>
 
     <dependency>
@@ -81,28 +88,28 @@
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
-      <version>5.2.9.RELEASE</version>
+      <version>${spring-test.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-core</artifactId>
-      <version>5.2.9.RELEASE</version>
+      <version>${spring-core.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter</artifactId>
-      <version>5.7.0</version>
+      <version>${junit-jupiter.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.mockito</groupId>
       <artifactId>mockito-all</artifactId>
-      <version>1.10.19</version>
+      <version>${mockito-all.version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Version of following third-party packages were updated.

commons-dbcp2 (2.7.0 -> 2.8.0)
commons-io (2.6 -> 2.8.0)
json (20200518 -> 20210307)
junit-jupiter (5.7.0 -> 5.7.2)
spring (5.2.9.RELEASE -> 5.3.7)
tomcat (9.0.43 -> 9.0.46)

Signed-off-by: Behera, Tushar Ranjan <tushar.ranjan.behera@intel.com>