### PR TITLE
Upgrading dependencies to the latest version

### DIFF
--- a/container/pom.xml
+++ b/container/pom.xml
@@ -21,11 +21,11 @@
     <commons-io.version>2.8.0</commons-io.version>
     <commons-dbcp2.version>2.8.0</commons-dbcp2.version>
     <commons-fileupload.version>1.4</commons-fileupload.version>
-    <h2.version>1.4.200</h2.version>
+    <h2.version>2.0.202</h2.version>
     <json.version>20210307</json.version>
     <slf4j-api.version>1.7.30</slf4j-api.version>
     <slf4j-simple.version>1.7.30</slf4j-simple.version>
-    <tomcat.version>9.0.53</tomcat.version>
+    <tomcat.version>9.0.56</tomcat.version>
     <rendezvous.war>rendezvous-${sdo.version}.war</rendezvous.war>
     <rvservice.war>rendezvous-service-${sdo.version}.war</rvservice.war>
     <manufacturer.war>manufacturer-webapp-${sdo.version}.war</manufacturer.war>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -24,12 +24,12 @@
   </parent>
 
   <properties>
-    <tomcat.version>9.0.53</tomcat.version>
-    <h2.version>1.4.200</h2.version>
+    <tomcat.version>9.0.56</tomcat.version>
+    <h2.version>2.0.202</h2.version>
     <json.version>20210307</json.version>
     <slf4j-api.version>1.7.30</slf4j-api.version>
-    <spring-test.version>5.3.7</spring-test.version>
-    <spring-core.version>5.3.7</spring-core.version>
+    <spring-test.version>5.3.13</spring-test.version>
+    <spring-core.version>5.3.13</spring-core.version>
     <junit-jupiter.version>5.7.2</junit-jupiter.version>
     <mockito-all.version>1.10.19</mockito-all.version>
   </properties>


### PR DESCRIPTION
  Upgrading dependencies to the latest version

  org.springframework.boot:spring.*  ==> 5.3.13
  tomcat => 9.0.56
  H2 database from 1.4.200 ==> 2.0.200

Signed-off-by: Davis Benny <davis.benny@intel.com>