### PR TITLE
Updating spring.jpa.ddl-auto property to none

### DIFF
--- a/container/overlay/tomcat/conf/catalina.properties
+++ b/container/overlay/tomcat/conf/catalina.properties
@@ -168,7 +168,15 @@ spring.datasource.driverClassName=org.h2.Driver
 spring.datasource.username=sa
 # NOTE: This is an example implementation using simplified credentials. This must be changed while performing production deployment.
 spring.datasource.password=
-spring.jpa.hibernate.ddl-auto=update
+
+# Accepted values for spring.jpa.hibernate.ddl-auto = {create, update, create-drop, validate, none}
+# update: update the schema
+# validate: validate the schema, makes no changes to the database.
+# create: creates the schema, cleans previous data.
+# none: make no changes to the DB schema. To be used in production settings.
+
+spring.jpa.hibernate.ddl-auto=none
+
 spring.jpa.open-in-view=false
 
 ## SDO component Keystore & Truststore Credentials


### PR DESCRIPTION
  Updating spring.jpa.ddl-auto property to `none`.

Signed-off-by: Davis Benny <davis.benny@intel.com>